### PR TITLE
[fix] 배포환경, 개발환경 모두 웹소켓 url이 정상적으로 작동하도록 수정

### DIFF
--- a/src/pages/Whiteboard.jsx
+++ b/src/pages/Whiteboard.jsx
@@ -51,7 +51,7 @@ const Whiteboard = () => {
     ctx.lineCap = 'round';
     ctxRef.current = ctx;
     const socket = new WebSocket(
-      `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${import.meta.env.VITE_WS_BASE_URL}?roomId=${roomId}`
+      `${import.meta.env.VITE_WS_BASE_URL}?roomId=${roomId}`
     );
     socketRef.current = socket;
 


### PR DESCRIPTION
# WebSocket 환경변수 처리 방식 개선

## 변경 내용
### 1. env.development / .env.production 파일을 구분하여 WebSocket URL을 환경별로 분리했습니다.
- 개발 환경에서는 직접 WebSocket 서버(localhost:8080/ws/canvas)에 연결
- 운영 환경에서는 클라이언트 도메인 기준의 상대경로(/ws/canvas)로 연결

### 2. 소켓 코드 자체를 환경변수에 전부 의존하도록 변경했습니다.
```
    const socket = new WebSocket(
      `${import.meta.env.VITE_WS_BASE_URL}?roomId=${roomId}`
    );
```

## 조건
### 두 가지의 환경 변수 파일을 직접 생성해야 합니다. (.env.development / .env.production)
```
#.env.development
VITE_WS_BASE_URL=ws://localhost:8080/ws/canvas
```
```
#.env.production
VITE_WS_BASE_URL=/ws/canvas
```
## 작동 방식
### 개발환경
- 개발 환경에서는 npm run dev 시 .env.development가 자동으로 적용됩니다.
VITE_WS_BASE_URL=ws://localhost:8080/ws/canvas

- const socket = new WebSocket(`${import.meta.env.VITE_WS_BASE_URL}?roomId=${roomId}`);
→ vite dev 서버(5173)에서 실행 중인 프론트가 직접 로컬호스트 8080 포트의 Spring Boot WebSocket 서버로 연결

---

### 배포환경
- 배포 환경에서는 npm run build 명령 실행 시 .env.production 파일이 적용됩니다.
VITE_WS_BASE_URL=/ws/canvas

- VITE_WS_BASE_URL=/ws/canvas 와 같이 상대경로를 사용함으로써, 브라우저는 현재 페이지 도메인을 기준으로 WebSocket을 연결하게 됩니다. (wss또는ws://배포도메인.com/ws/canvas)

- 운영 서버 내부에서 NGINX가 /ws/canvas 요청을 내부의 Spring Boot WebSocket 서버로 프록시 처리 하기 때문에 정상적으로 웹소켓 연결이 됩니다.

```
#nginx 설정 일부
location /ws/ {
    proxy_pass http://스프링부트서버ec2사설망주소:8080;  # Spring Boot WebSocket 서버
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
}
```

<img width="978" alt="image" src="https://github.com/user-attachments/assets/83a0dede-f06d-4fbb-b899-18bc5ec5fe97" />

